### PR TITLE
Add snackbar context provider

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,26 +1,19 @@
 import './App.css';
-import { PublicClientApplication } from "@azure/msal-browser";
-import { MsalProvider } from "@azure/msal-react";
-import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
-import PageLayout from './components/PageLayout.tsx';
-import LandingPage from './pages/Landing.tsx';
-import PetPage from './pages/PetPage.tsx';
+import {PublicClientApplication} from "@azure/msal-browser";
+import {MsalProvider} from "@azure/msal-react";
+import MainContent from "./MainContent.tsx";
+import {SnackbarProvider} from "./providers/SnackbarProvider.tsx";
 
 interface AppProps {
     instance: PublicClientApplication;
 }
 
-const App = ({ instance }: AppProps) => {
+const App = ({instance}: AppProps) => {
     return (
         <MsalProvider instance={instance}>
-            <Router>
-                <PageLayout>
-                    <Routes>
-                        <Route path="/" element={<LandingPage />} />
-                        <Route path="/pets" element={<PetPage />} />
-                    </Routes>
-                </PageLayout>
-            </Router>
+            <SnackbarProvider>
+                <MainContent/>
+            </SnackbarProvider>
         </MsalProvider>
     );
 };

--- a/frontend/src/providers/SnackbarProvider.tsx
+++ b/frontend/src/providers/SnackbarProvider.tsx
@@ -1,0 +1,39 @@
+import {useState} from "react";
+import {createContext} from "react";
+import {Alert, Snackbar} from "@mui/material";
+
+interface SnackbarContextType {
+    showSnackbar: (message: string, severity?: 'success' | 'error' | 'warning' | 'info') => void;
+}
+
+export const SnackbarContext = createContext<SnackbarContextType>({
+    showSnackbar: () => {}
+});
+
+// Snackbar Provider
+export const SnackbarProvider: React.FC<{ children: React.ReactNode }> = ({children}) => {
+    const [open, setOpen] = useState(false);
+    const [message, setMessage] = useState('');
+    const [severity, setSeverity] = useState<'success' | 'error' | 'warning' | 'info'>('info');
+
+    const showSnackbar = (message: string, severity: 'success' | 'error' | 'warning' | 'info' = 'info') => {
+        setMessage(message);
+        setSeverity(severity);
+        setOpen(true);
+    };
+
+    const handleClose = () => {
+        setOpen(false);
+    };
+
+    return (
+        <SnackbarContext.Provider value={{showSnackbar}}>
+            {children}
+            <Snackbar open={open} autoHideDuration={6000} onClose={handleClose}>
+                <Alert onClose={handleClose} severity={severity}>
+                    {message}
+                </Alert>
+            </Snackbar>
+        </SnackbarContext.Provider>
+    );
+};

--- a/frontend/src/providers/SnackbarProvider.tsx
+++ b/frontend/src/providers/SnackbarProvider.tsx
@@ -6,6 +6,13 @@ interface SnackbarContextType {
     showSnackbar: (message: string, severity?: 'success' | 'error' | 'warning' | 'info') => void;
 }
 
+export const SNACKBAR_SEVERITY = {
+    SUCCESS: 'success',
+    ERROR: 'error',
+    WARNING: 'warning',
+    INFO: 'info'
+} as const;
+
 export const SnackbarContext = createContext<SnackbarContextType>({
     showSnackbar: () => {}
 });


### PR DESCRIPTION
## What changed?

1. Added a context provider to use a snackbar from anywhere in the app

## Usage
Example:
```
// ExampleSnackbarUsageComponent
export const ExampleSnackbarUsageComponent = () => {
    const {showSnackbar} = useContext(SnackbarContext);
    const clickHandler = () => {
        showSnackbar("I am a snackbar", SNACKBAR_SEVERITY.SUCCESS)
    }
    return (
        <Button onClick={clickHandler}>
            Show Snackbar
        </Button>
    )
}
```