### PR TITLE
Implement display health record

### DIFF
--- a/frontend/src/pages/pet/PetCard.tsx
+++ b/frontend/src/pages/pet/PetCard.tsx
@@ -2,6 +2,7 @@ import {Avatar, Box, Card, CardContent, Chip, Typography} from "@mui/material";
 import {Pet} from "../../api/types/pet.ts";
 import React from "react";
 import {calculateAge} from "./util/ageCalculator.ts";
+import {toProperCase} from "../../util/toProperCase.ts";
 
 export interface PetCardProps {
     pet: Pet;
@@ -51,14 +52,14 @@ export const PetCard : React.FC<PetCardProps> = ({pet,selectedPet,handleOpenPet}
                 </Typography>
                 <Box sx={{display: 'flex', mt: 1, gap: 1}}>
                     <Chip
-                        label={pet.species}
+                        label={toProperCase(pet.species)}
                         size="small"
                         color="primary"
                         variant="outlined"
                         sx={{bgcolor: 'rgba(255,255,255,0.8)', color: 'primary.dark'}}
                     />
                     <Chip
-                        label={pet.breed}
+                        label={toProperCase(pet.breed)}
                         size="small"
                         color="primary"
                         variant="outlined"
@@ -83,26 +84,6 @@ export const PetCard : React.FC<PetCardProps> = ({pet,selectedPet,handleOpenPet}
                     </Typography>
                 </Box>
             </CardContent>
-            {/*<Box sx={{*/}
-            {/*    p: 2,*/}
-            {/*    width: '100%',*/}
-            {/*    display: 'flex',*/}
-            {/*    flexDirection: 'column',*/}
-            {/*    alignItems: 'center'*/}
-            {/*}}>*/}
-            {/*    /!* Circular Avatar *!/*/}
-            {/*    <Avatar*/}
-            {/*        src={pet.photoUrl}*/}
-            {/*        alt={pet.name}*/}
-            {/*        sx={{width: 80, height: 80, mb: 1}}*/}
-            {/*    />*/}
-            {/*    <CardContent sx={{textAlign: "center", p: 1, "&:last-child": {pb: 1}}}>*/}
-            {/*        <Typography variant="h6" fontWeight="bold">{pet.name}</Typography>*/}
-            {/*        <Typography variant="body2" color="text.secondary">*/}
-            {/*            {pet.species} • {pet.breed}*/}
-            {/*        </Typography>*/}
-            {/*    </CardContent>*/}
-            {/*</Box>*/}
         </Card>
     )
 }

--- a/frontend/src/pages/pet/PetDetailsPanel.tsx
+++ b/frontend/src/pages/pet/PetDetailsPanel.tsx
@@ -19,6 +19,7 @@ import {Timeline, TimelineConnector, TimelineContent, TimelineDot, TimelineItem,
 import {Pet} from "../../api/types/pet.ts";
 import VaccinationRecord from "../../api/types/vaccinationRecord.ts";
 import Divider from "@mui/material/Divider";
+import {toProperCase} from "../../util/toProperCase.ts";
 
 interface PetDetailsPopupContentProps {
     pet: Pet;
@@ -47,7 +48,7 @@ export const PetDetailsPanel: React.FC<PetDetailsPopupContentProps> = ({pet, vac
             label: 'Gender',
             icon: pet.gender === 'Male' ? <MaleOutlined color="primary"/> : <FemaleOutlined color="secondary"/>
         },
-        {key: 'species', label: 'Type', icon: <PetsOutlined/>},
+        {key: 'species', label: 'Type', icon: <PetsOutlined/>, format: (value) => toProperCase(value.toString())},
         {key: 'breed', label: 'Breed', icon: <PetsOutlined/>},
         {key: 'dateOfBirth', label: 'Date of Birth', icon: <CakeOutlined/>},
         {key: 'weight', label: 'Weight', icon: <ScaleOutlined/>, format: (value) => `${value} kg`},

--- a/frontend/src/pages/pet/PetDetailsPopup.tsx
+++ b/frontend/src/pages/pet/PetDetailsPopup.tsx
@@ -1,8 +1,14 @@
 import {Pet} from "../../api/types/pet.ts";
 import React from "react";
-import {Button, Dialog, DialogActions, DialogContent, DialogTitle} from "@mui/material";
+import {Button, Chip, Dialog, DialogActions, DialogContent, DialogTitle, Grid2, useTheme} from "@mui/material";
 import Typography from "@mui/material/Typography";
 import Avatar from "@mui/material/Avatar";
+import IconButton from "@mui/material/IconButton";
+import CloseIcon from "@mui/icons-material/Close";
+import Box from "@mui/material/Box";
+import Divider from "@mui/material/Divider";
+import PetsIcon from "@mui/icons-material/Pets";
+import {toProperCase} from "../../util/toProperCase.ts";
 
 interface PetDetailsPopupProps {
     pet: Pet;
@@ -13,56 +19,159 @@ type PetPropertyConfig<K extends keyof Pet> = {
     key: K;
     label: string;
     format?: (value: Pet[K]) => string;
+    icon?: React.ReactNode;
+    important?: boolean
 };
 
 const PetDetailsPopup: React.FC<PetDetailsPopupProps> = ({pet, onClose}) => {
     // Define the properties with proper typing
+    const theme = useTheme();
     const petProperties: PetPropertyConfig<keyof Pet>[] = [
-        {key: 'gender', label: 'Gender'},
-        {key: 'species', label: 'Type'},
-        {key: 'breed', label: 'Breed'},
-        {key: 'dateOfBirth', label: 'Date of Birth'},
+        {key: 'species', label: 'Type', important: true},
+        {key: 'breed', label: 'Breed', important: true},
+        {key: 'gender', label: 'Gender', important: true},
+        {key: 'dateOfBirth', label: 'Date of Birth', important: true},
         {key: 'weight', label: 'Weight', format: (value) => `${value} kg`},
         {key: 'height', label: 'Height', format: (value) => `${value} cm`},
         {key: 'neckGirthCm', label: 'Neck Girth', format: (value) => `${value} cm`},
         {key: 'chestGirthCm', label: 'Chest Girth', format: (value) => `${value} cm`},
-        {key: 'lastMeasured', label: 'Last Measured Date'},
+        {key: 'lastMeasured', label: 'Last Measured'},
         {key: 'isNeutered', label: 'Neutered', format: (value) => value ? 'Yes' : 'No'},
         {key: 'microchipNumber', label: 'Microchip Number'},
-        {key: 'createdAt', label: 'Created At'},
-        {key: 'updatedAt', label: 'Updated At'}
+        {key: 'createdAt', label: 'Added on'},
+        {key: 'updatedAt', label: 'Updated'}
     ];
+    const importantProperties = petProperties.filter(prop => prop.important);
+    const standardProperties = petProperties.filter(prop => !prop.important);
 
-    const petDetails = petProperties.map(property => {
-        const value = pet[property.key];
 
-        // Skip null or undefined values
-        if (value === null || value === undefined) return null;
-
-        // Format the value if a formatter is provided
-        const displayValue = property.format
-            ? property.format(value)
-            : String(value);
-
-        return (
-            <Typography key={property.key}>{property.label}: {displayValue}</Typography>
-        );
-    });
     return (
-        <Dialog open={Boolean(pet)} onClose={onClose}>
-            <DialogTitle>{pet.name}</DialogTitle>
-            <DialogContent>
-                <Avatar
-                    src={pet.photoUrl}
-                    alt={pet.name}
+        <Dialog
+            open={Boolean(pet)}
+            onClose={onClose}
+            fullWidth={true}
+            maxWidth={"sm"}
+            sx={{borderRadius: 2, overflow: 'hidden'}}
+        >
+            <DialogTitle
+                sx={{
+                    p: 0,
+                    position: 'relative',
+                    height: 200,
+                    backgroundImage: `linear-gradient(to bottom, ${theme.palette.primary.light}, ${theme.palette.primary.main})`,
+                    color: 'white'
+                }}
+            >
+                <IconButton
+                    onClick={onClose}
                     sx={{
-                        width: 120,
-                        height: 120,
-                        border: '4px solid white',
-                        mb: 2
+                        position: 'absolute',
+                        right: 8,
+                        top: 8,
+                        color: 'white',
+                        bgcolor: 'rgba(0,0,0,0.2)',
+                        '&:hover': {
+                            bgcolor: 'rgba(0,0,0,0.4)'
+                        }
                     }}
-                />
-                {petDetails}
+                >
+                    <CloseIcon/>
+                </IconButton>
+
+                <Box
+                    sx={{
+                        position: 'absolute',
+                        bottom: 0,
+                        left: 0,
+                        right: 0,
+                        display: 'flex',
+                        flexDirection: 'column',
+                        alignItems: 'center',
+                        justifyContent: 'center'
+                    }}
+                >
+                    <Avatar
+                        src={pet.photoUrl}
+                        alt={pet.name}
+                        sx={{
+                            width: 100,
+                            height: 100,
+                            border: '4px solid white',
+                            boxShadow: 3
+                        }}
+                    />
+                    <Typography
+                        variant="h5"
+                        fontWeight="bold"
+                        sx={{
+                            mt: 1,
+                            textShadow: '1px 1px 3px rgba(0,0,0,0.3)',
+                            px: 2,
+                            py: 0.5,
+                            borderRadius: 1
+                        }}
+                    >
+                        {pet.name}'s Health Records
+                    </Typography>
+                </Box>
+            </DialogTitle>
+            <DialogContent sx={{pt: 7, pb: 3}}>
+                <Grid2 container spacing={2} sx={{my: 3}}>
+                    {importantProperties.map(property => {
+                        const value = pet[property.key];
+                        if (value === null || value === undefined) return null;
+                        const displayValue = property.format ? property.format(value) : String(value);
+                        return (
+                            <Grid2 size={6} key={property.key}>
+                                <Box sx={{
+                                    // display: 'flex',
+                                    alignItems: 'center',
+                                    p: 1,
+                                    borderRadius: 2,
+                                    bgcolor: '#f5f5f5'
+                                }}>
+                                    <Typography variant="body2" color="text.secondary" gutterBottom>
+                                        {toProperCase(property.label)}
+                                    </Typography>
+                                    <Typography variant="body1" fontWeight="medium">
+                                        {toProperCase(displayValue)}
+                                    </Typography>
+                                </Box>
+                            </Grid2>
+                        )
+                    })}
+                </Grid2>
+                <Divider sx={{my: 3}}>
+                    <Chip
+                        icon={<PetsIcon/>}
+                        label="Details"
+                        size="small"
+                        sx={{px: 1}}
+                    />
+                </Divider>
+                <Grid2 container spacing={2}>
+                    {standardProperties.map(property => {
+                        const value = pet[property.key];
+                        if (value === null || value === undefined) return null;
+
+                        const displayValue = property.format
+                            ? property.format(value)
+                            : String(value);
+
+                        return (
+                            <Grid2 size={{sm: 6, xs: 12}} key={property.key}>
+                                <Box sx={{display: 'flex', justifyContent: 'space-between'}}>
+                                    <Typography variant="body2" color="text.secondary">
+                                        {property.label}:
+                                    </Typography>
+                                    <Typography variant="body2">
+                                        {displayValue}
+                                    </Typography>
+                                </Box>
+                            </Grid2>
+                        );
+                    })}
+                </Grid2>
             </DialogContent>
             <DialogActions>
                 <Button onClick={onClose}>Close</Button>

--- a/frontend/src/util/toProperCase.ts
+++ b/frontend/src/util/toProperCase.ts
@@ -1,0 +1,9 @@
+export const toProperCase = (str: string): string => {
+    if (!str) return '';
+
+    return str
+        .toLowerCase()
+        .split(' ')
+        .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+        .join(' ');
+};


### PR DESCRIPTION
This pull request includes several changes to improve the display and formatting of pet information in the frontend components. The most important changes include the addition of the `toProperCase` utility function, updates to the `PetCard` and `PetDetailsPanel` components to use this function, and significant enhancements to the `PetDetailsPopup` component.

### Formatting Improvements:

* [`frontend/src/util/toProperCase.ts`](diffhunk://#diff-6dd0a5581cdfefe51dc29f60d7f3a3e738b84bd9dd715e91fa10e093847299a7R1-R9): Added a new utility function `toProperCase` to convert strings to proper case.

### Component Updates:

* [`frontend/src/pages/pet/PetCard.tsx`](diffhunk://#diff-3514c6b86594b462c3e89447d72ca489aa7456fbffa1930faa97b8af76c9a228R5): Updated the `PetCard` component to use the `toProperCase` function for displaying pet species and breed in proper case. [[1]](diffhunk://#diff-3514c6b86594b462c3e89447d72ca489aa7456fbffa1930faa97b8af76c9a228R5) [[2]](diffhunk://#diff-3514c6b86594b462c3e89447d72ca489aa7456fbffa1930faa97b8af76c9a228L54-R62)
* [`frontend/src/pages/pet/PetDetailsPanel.tsx`](diffhunk://#diff-bd51db0947bca4f6637dfb48fc725aa6b0bee1cb354604b90a6a72c53730c569R22): Modified the `PetDetailsPanel` component to use the `toProperCase` function for formatting the species type. [[1]](diffhunk://#diff-bd51db0947bca4f6637dfb48fc725aa6b0bee1cb354604b90a6a72c53730c569R22) [[2]](diffhunk://#diff-bd51db0947bca4f6637dfb48fc725aa6b0bee1cb354604b90a6a72c53730c569L50-R51)
* `frontend/src/pages/pet/PetDetailsPopup.tsx`: Enhanced the `PetDetailsPopup` component with several improvements:
  * Added new imports for `Chip`, `Grid2`, `useTheme`, `IconButton`, `CloseIcon`, `Box`, `Divider`, and `PetsIcon`.
  * Introduced `icon` and `important` properties to the `PetPropertyConfig` type.
  * Separated pet properties into important and standard categories and updated the layout to highlight important properties.
  * Enhanced the dialog title with a gradient background, close button, and pet avatar. [[1]](diffhunk://#diff-099998180f183576bacf0c4ee1819581877057376035df146158e4a3f87bde27L3-R11) [[2]](diffhunk://#diff-099998180f183576bacf0c4ee1819581877057376035df146158e4a3f87bde27R22-R174)