### PR TITLE
Fix user api should user preferred username

### DIFF
--- a/backend/src/routes/users/users.controller.ts
+++ b/backend/src/routes/users/users.controller.ts
@@ -2,10 +2,10 @@ import UsersService from "./users.service";
 const logger = require('../../utils/logger');
 
 const UsersController = {
-  retrieveUser: async (account_name: string) => {
+  retrieveUser: async (preferred_username: string) => {
     try {
-      const users = await UsersService.retrieveUser(account_name);
-      return users;
+      const user = await UsersService.retrieveUser(preferred_username);
+      return user;
     } catch (error) {
       logger.error(error);
       throw new Error("Error retrieving user");

--- a/backend/src/routes/users/users.service.ts
+++ b/backend/src/routes/users/users.service.ts
@@ -6,10 +6,10 @@ import { format } from 'date-fns';
 const models = sequelize.models;
 
 const UsersServices = {
-  retrieveUser: async (account_name: string) => {
-    const users = await models.USERS.findOne({
+  retrieveUser: async (preferred_username: string) => {
+    const user = await models.USERS.findOne({
       where: {
-        account_name
+        preferred_username
       },
       include: [
         {
@@ -17,7 +17,7 @@ const UsersServices = {
         }
       ]
     });
-    return users;
+    return user;
   },
   registerUser: async (user: any) => {
     try {

--- a/backend/src/routes/users/users.service.ts
+++ b/backend/src/routes/users/users.service.ts
@@ -9,7 +9,7 @@ const UsersServices = {
   retrieveUser: async (preferred_username: string) => {
     const user = await models.USERS.findOne({
       where: {
-        preferred_username
+        email: preferred_username,
       },
       include: [
         {

--- a/backend/src/routes/users/users.ts
+++ b/backend/src/routes/users/users.ts
@@ -4,49 +4,87 @@ const logger = require('../../utils/logger');
 export const users = express.Router();
 
 /**
-  * @swagger
-  * 
-  * /users/retrieveUser:
-  *   get:
-  *    summary: Retrieve a single JSONPlaceholder user.
-  *    tags:
-  *      - users
-  *    description: Retrieve a single JSONPlaceholder user. Can be used to populate a user profile when prototyping or testing an API.
-  *    responses:
-  *      200:
-  *        description: Logged in user details.
-  *        content:
-  *          application/json:
-  *            schema:
-  *              type: object
-  *              properties:
-  *                data:
-  *                  type: array
-  *                  items:
-  *                    type: object
-  *                    properties:
-  *                      id:
-  *                        type: string
-  *                        description: The user ID.
-  *                        example: 0
-  *                      name:
-  *                        type: string
-  *                        description: The user's name.
-  *                        example: Leanne Bob
-  */
+ * @swagger
+ *
+ * /users/retrieveUser:
+ *   get:
+ *    summary: Retrieve the current user's profile.
+ *    tags:
+ *      - users
+ *    description: Retrieves the user profile based on the preferred_username extracted from the Azure access token.
+ *    responses:
+ *      200:
+ *        description: User details with success or error status.
+ *        content:
+ *          application/json:
+ *            schema:
+ *              type: object
+ *              properties:
+ *                status:
+ *                  type: string
+ *                  enum: [success, error]
+ *                  description: Status of the request.
+ *                  example: success
+ *                message:
+ *                  oneOf:
+ *                    - type: object
+ *                      properties:
+ *                        id:
+ *                          type: string
+ *                          description: The user ID.
+ *                          example: "1f005b07-46cb-6670-85cc-854ff2948567"
+ *                        account_name:
+ *                          type: string
+ *                          description: The user's account name (matches preferred_username).
+ *                          example: "xueyang"
+ *                        display_name:
+ *                          type: string
+ *                          description: The user's display name.
+ *                          example: "xueyang"
+ *                        email:
+ *                          type: string
+ *                          description: The user's email address.
+ *                          example: "pangxueyang@gmail.com"
+ *                        last_active:
+ *                          type: string
+ *                          format: date-time
+ *                          description: Last active timestamp.
+ *                          example: "2025-03-20 17:26:27"
+ *                        account_created:
+ *                          type: string
+ *                          format: date-time
+ *                          description: Account creation timestamp.
+ *                          example: "2025-03-20 17:26:27"
+ *                        bio:
+ *                          type: string
+ *                          description: User's biography.
+ *                          example: "kiyo's owner"
+ *                        profile_picture:
+ *                          type: string
+ *                          description: URL or hash of profile picture.
+ *                          example: ""
+ *                        VET:
+ *                          type: object
+ *                          nullable: true
+ *                          description: Veterinarian details if the user is a vet.
+ *                          example: null
+ *                    - type: string
+ *                      description: Error message when user is not found.
+ *                      example: "User not found"
+ */
 users.get('/retrieveUser', async (req: Request, res: Response): Promise<void> => {
     // res.send(`Retrieving user ${req.params.id}`);
     const userInfo = req.headers.userInfo as any;
     try {
-      const result: any = await UsersController.retrieveUser(userInfo?.preferred_username);
-      if (result.length === 0) {
-        res.status(200).type('text').send({status: 'error', message: 'User not found'});
-      } else {
-        res.status(200).type('json').send({status: 'success', message: result});
-      }
+        const result: any = await UsersController.retrieveUser(userInfo?.preferred_username);
+        if (result === null || result === undefined ||result.length === 0) {
+            res.status(200).type('text').send({status: 'error', message: 'User not found'});
+        } else {
+            res.status(200).type('json').send({status: 'success', message: result});
+        }
     } catch (error) {
-      logger.error(error);
-      res.status(200).type('text').send({status: 'error', message: error});
+        logger.error(error);
+        res.status(200).type('text').send({status: 'error', message: error});
     }
 });
 

--- a/frontend/src/api/types/user.ts
+++ b/frontend/src/api/types/user.ts
@@ -1,15 +1,13 @@
 // src/api/types/user.ts
+// User interface
 export interface User {
-    ID: string; 
-    account_name: string;
-    display_name: string;
-    email: string;
-    last_active: string;
-    bio: string;
-    profile_picture: string;
-    ACCOUNT_TYPE: string;
-    account_created: string;
-    isDeleted: boolean;
+    ID?: string;
+    account_name?: string;
+    display_name?: string;
+    email?: string;
+    account_type?: string;
+    bio?: string;
+    profile_picture?: string;
 }
 
 export interface UserCreateInput extends Omit<User, 'id'> {


### PR DESCRIPTION
### Updates to user retrieval functionality:

The acute access token provides only preferred_username (which is the user's email) as an identifier.
Our backend API was querying the database using account_name to find users, which resulted in failed lookups since this field may not match the email.
When users register with different values for account_name or display_name that don't match their email, the user lookup also fails.

### Modified the user retrieval flow to:
Use the preferred_username(which is the user's email,  value from the Azure accessToken 
Query the database using the email field instead of the account_name field.

* [`backend/src/routes/users/users.controller.ts`](diffhunk://#diff-0388f878ba8ce553811c08882a7f043404a922d244df2cd98a94a482e480acbfL5-R8): Changed the parameter name from `account_name` to `preferred_username` in the `retrieveUser` method because the azure access token only has preferred_username. 
* [`backend/src/routes/users/users.service.ts`](diffhunk://#diff-2f927ea32c64c2f34ae5f4cdee2d89394f7f73329892729516633fed85e4a45bL9-R20): Updated the `retrieveUser` method to use `preferred_username` instead of `account_name` and adjusted the return value to be a single user object.
