### PR TITLE
Ph 48 create notification page

### DIFF
--- a/frontend/src/components/HeaderBar.tsx
+++ b/frontend/src/components/HeaderBar.tsx
@@ -81,10 +81,12 @@ const HeaderBar = ({onMenuClick, onNotificationDrawerClick}: HeaderBarProps) => 
                         Pet Health Platform
                     </Typography>
                     <div style={{marginLeft: 'auto'}}>
-                        <IconButton color="inherit" onClick={onNotificationDrawerClick}
-                                    sx={{'&:hover': {transform: 'scale(1.1)', transition: 'transform 0.2s'}}}>
-                            <Mail/>
-                        </IconButton>
+                        {activeAccount &&
+                            <IconButton color="inherit" onClick={onNotificationDrawerClick}
+                                        sx={{'&:hover': {transform: 'scale(1.1)', transition: 'transform 0.2s'}}}>
+                                <Mail/>
+                            </IconButton>
+                        }
                         <IconButton color="inherit" onClick={handleMenu}
                                     sx={{'&:hover': {transform: 'scale(1.1)', transition: 'transform 0.2s'}}}>
                             <AccountCircle/>

--- a/frontend/src/components/Notifications/NotificationDrawer.tsx
+++ b/frontend/src/components/Notifications/NotificationDrawer.tsx
@@ -15,6 +15,7 @@ import {useContext, useEffect} from "react";
 import {NotificationCreateModal} from "./CreateNotificationModal.tsx";
 import {NotificationsListModal} from "./NotificationsListModal.tsx";
 import {ApiClientContext} from "../../providers/ApiClientProvider.tsx";
+import {useMsal} from "@azure/msal-react";
 
 type NotificationDrawerProps = {
     isOpen: boolean;
@@ -23,6 +24,8 @@ type NotificationDrawerProps = {
 
 export const NotificationDrawer = ({isOpen, toggleDrawer}: NotificationDrawerProps) => {
     const theme = useTheme();
+    const { instance } = useMsal();
+    const activeAccount = instance.getActiveAccount();
     const { userApi } = useContext(ApiClientContext);
     const [isVet, setIsVet] = React.useState(false);
     const [isSettingsOpen, setIsSettingsOpen] = React.useState(false);
@@ -36,22 +39,24 @@ export const NotificationDrawer = ({isOpen, toggleDrawer}: NotificationDrawerPro
     const closeNotificationSettings = () => setIsSettingsOpen(false);
 
     useEffect(() => {
-
-        const fetchUserProfile = async () => {
-            try {
-                const result = await userApi.retrieveUser();
-                if (result?.success && result.data) {
-                    console.info(result.data);
-                    setIsVet(!!result.data.VET)
-                } else {
-                    console.error(result.message);
+        console.info(`activeAccount: ${activeAccount}`);
+        if(activeAccount) {
+            const fetchUserProfile = async () => {
+                try {
+                    const result = await userApi.retrieveUser();
+                    if (result?.success && result.data) {
+                        console.info(result.data);
+                        setIsVet(!!result.data.VET)
+                    } else {
+                        console.error(result.message);
+                    }
+                } catch (err) {
+                    console.error(err);
                 }
-            } catch (err) {
-                console.error(err);
-            }
-        };
-        fetchUserProfile();
-    }, []);
+            };
+            fetchUserProfile();
+        }
+    }, [activeAccount]);
 
     const listItems = [
         {


### PR DESCRIPTION
ensure that certain features are only accessible when an active account is available

### Notification functionality enhancements:

* [`frontend/src/components/Notifications/NotificationDrawer.tsx`](diffhunk://#diff-07d35fc9d3fbf6825ec4bde78d85ec5ce1bfb71c2bde5c8a1b20443224082fb2R18): Integrated `useMsal` to retrieve the active account and modified the `useEffect` hook to log and conditionally fetch the user profile only when an active account exists. This ensures that user-specific actions are tied to the logged-in account. [[1]](diffhunk://#diff-07d35fc9d3fbf6825ec4bde78d85ec5ce1bfb71c2bde5c8a1b20443224082fb2R18) [[2]](diffhunk://#diff-07d35fc9d3fbf6825ec4bde78d85ec5ce1bfb71c2bde5c8a1b20443224082fb2R27-R28) [[3]](diffhunk://#diff-07d35fc9d3fbf6825ec4bde78d85ec5ce1bfb71c2bde5c8a1b20443224082fb2L39-R43) [[4]](diffhunk://#diff-07d35fc9d3fbf6825ec4bde78d85ec5ce1bfb71c2bde5c8a1b20443224082fb2L54-R59)

### User interface improvements:

* [`frontend/src/components/HeaderBar.tsx`](diffhunk://#diff-ce1a4c9ced4ddb4bef52f59274db06cdf68e0fcb62280a564456dc38fd279ed2R84-R89): Updated the `HeaderBar` component to conditionally display the notification mail icon only when an active account is present